### PR TITLE
Make sidebar header one line and always show state headers

### DIFF
--- a/src/Overview/OverviewHeader.tsx
+++ b/src/Overview/OverviewHeader.tsx
@@ -9,7 +9,19 @@ const useStyles = createStyles((theme, _params, getRef) => ({
     flexGrow: 0,
     label: 'loops-header',
 
-    borderBottom: 'var(--jp-border-width) solid var(--jp-toolbar-border-color)'
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: '1em'
+
+    // borderBottom: 'var(--jp-border-width) solid var(--jp-toolbar-border-color)'
+  },
+  title: {
+    margin: '0 0.5em'
+  },
+  file: {
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis'
   }
 }));
 
@@ -44,10 +56,10 @@ export function OverviewHeader({ labShell }: IOverviewHeaderProps): JSX.Element 
 
   return (
     <header className={classes.loopsHeader}>
-      <div className="title">
+      <div className={classes.title}>
         <LoopsLogo height={30} />
       </div>
-      <div>
+      <div className={classes.file}>
         {icon && (
           <icon.react
             tag="span"

--- a/src/Overview/OverviewHeader.tsx
+++ b/src/Overview/OverviewHeader.tsx
@@ -8,16 +8,14 @@ const useStyles = createStyles((theme, _params, getRef) => ({
   loopsHeader: {
     flexGrow: 0,
     label: 'loops-header',
+    height: '2em',
 
     display: 'flex',
     justifyContent: 'space-between',
-    gap: '1em'
-
-    // borderBottom: 'var(--jp-border-width) solid var(--jp-toolbar-border-color)'
+    gap: '1em',
+    padding: '0.1em 0.5em'
   },
-  title: {
-    margin: '0 0.5em'
-  },
+  title: {},
   file: {
     overflow: 'hidden',
     whiteSpace: 'nowrap',
@@ -57,13 +55,12 @@ export function OverviewHeader({ labShell }: IOverviewHeaderProps): JSX.Element 
   return (
     <header className={classes.loopsHeader}>
       <div className={classes.title}>
-        <LoopsLogo height={30} />
+        <LoopsLogo height={38} />
       </div>
       <div className={classes.file}>
         {icon && (
           <icon.react
             tag="span"
-            marginRight="0.25em"
             height="16px"
             verticalAlign="sub" // looks slightly better then middle
           />

--- a/src/Overview/State.tsx
+++ b/src/Overview/State.tsx
@@ -166,28 +166,22 @@ export function State({ state, stateNo, previousState, stateDoI, cellExecutionCo
   }
 
   const activeCellId = useLoopStore(state => state.activeCellID);
+  // activeCellTop = distance of the notebook's active cell to the top of the window
   const activeCellTop = useLoopStore(state => state.activeCellTop);
   const stateScrollerRef = useRef<HTMLDivElement>(null);
-  const stateHeaderRef = useRef<HTMLDivElement>(null);
   const scrollToElement = () => {
+    // provCellTop = distance of the provenance's corresponding cell to the top of the extension
     const provCellTop = stateScrollerRef.current?.querySelector<HTMLDivElement>(
       `[data-cell-id="${activeCellId}"]`
     )?.offsetTop;
-    const headerHeight = stateHeaderRef.current?.offsetHeight || 0;
+    // activeCellTop and provCellTop are calculated relative to different elements, align them by adding the height of the top panel
+    const jpTopPanelHeight = document.querySelector<HTMLDivElement>('#jp-top-panel')?.offsetHeight || 0;
+    // the notebook cells have some padding at the top that needs to be considered in order to align the cells properly
     const jpCellPadding =
       parseInt(getComputedStyle(document.documentElement).getPropertyValue('--jp-cell-padding')) || 0;
 
     if (activeCellTop && provCellTop) {
-      const scrollPos = provCellTop - activeCellTop + headerHeight - jpCellPadding;
-      // log all aprts of the computation
-      console.log('scrollToElement', {
-        activeCellTop,
-        provCellTop,
-        headerHeight,
-        jpCellPadding,
-        calc: `${provCellTop} - ${activeCellTop} + ${headerHeight} - ${jpCellPadding}`,
-        scrollPos
-      });
+      const scrollPos = provCellTop - activeCellTop + jpTopPanelHeight - jpCellPadding;
       stateScrollerRef.current?.scrollTo({ top: scrollPos, behavior: 'instant' });
     }
   };
@@ -240,7 +234,7 @@ export function State({ state, stateNo, previousState, stateDoI, cellExecutionCo
         [classes.wideState]: fullWidth // disable flexShrink if the state is full width
       })}
     >
-      <header ref={stateHeaderRef} className={cx(classes.header, classes.dashedBorder)}>
+      <header className={cx(classes.header, classes.dashedBorder)}>
         <Center>
           <ActionIcon onClick={toggleFullwidth} title={fullWidth ? 'collapse' : 'expand'}>
             {fullWidth ? <IconArrowsDiff /> : <IconArrowsHorizontal />}

--- a/src/Overview/State.tsx
+++ b/src/Overview/State.tsx
@@ -12,14 +12,24 @@ import { mergeArrays } from '../util';
 import { ExecutionBadge } from './ExecutionBadge';
 
 const useStyles = createStyles((theme, _params, getRef) => ({
+  header: {
+    borderBottom: 'var(--jp-border-width) solid var(--jp-toolbar-border-color)'
+  },
   stateWrapper: {
-    padding: '0.5rem',
+    label: 'wrapper',
+
+    overflowY: 'hidden',
+
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'stretch',
 
     // sizing within the state list (Default = compact)
     minWidth: '3rem',
-    maxWidth: '3rem',
-    label: '1rapper',
-
+    maxWidth: '3rem'
+  },
+  stateScroller: {
+    label: 'scroller',
     overflowY: 'auto'
   },
   wideState: {
@@ -45,6 +55,7 @@ const useStyles = createStyles((theme, _params, getRef) => ({
     '& .jp-Cell': {
       border: '1px solid #bdbdbd',
       padding: '0',
+      margin: '0 0.25rem',
       borderRadius: '0.5rem',
       position: 'relative',
 
@@ -120,9 +131,13 @@ const useStyles = createStyles((theme, _params, getRef) => ({
   versionSplit: {
     label: 'version-split',
     borderTop: '1px dashed #bdbdbd',
-    margin: '1em 0',
+    marginTop: '1em',
     textAlign: 'center',
     padding: '0.5em 0'
+  },
+  dashedBorder: {
+    // borderLeft: 'var(--jp-border-width) dotted var(--jp-toolbar-border-color)',
+    borderRight: 'var(--jp-border-width) dotted var(--jp-toolbar-border-color)'
   }
 }));
 
@@ -152,24 +167,37 @@ export function State({ state, stateNo, previousState, stateDoI, cellExecutionCo
 
   const activeCellId = useLoopStore(state => state.activeCellID);
   const activeCellTop = useLoopStore(state => state.activeCellTop);
-  const stateWrapperRef = useRef<HTMLDivElement>(null);
+  const stateScrollerRef = useRef<HTMLDivElement>(null);
   const stateHeaderRef = useRef<HTMLDivElement>(null);
-
   const scrollToElement = () => {
-    const provCellTop = stateWrapperRef.current?.querySelector<HTMLDivElement>(
+    const provCellTop = stateScrollerRef.current?.querySelector<HTMLDivElement>(
       `[data-cell-id="${activeCellId}"]`
     )?.offsetTop;
     const headerHeight = stateHeaderRef.current?.offsetHeight || 0;
+    const jpCellPadding =
+      parseInt(getComputedStyle(document.documentElement).getPropertyValue('--jp-cell-padding')) || 0;
 
     if (activeCellTop && provCellTop) {
-      const scrollPos = provCellTop - activeCellTop + headerHeight;
-      stateWrapperRef.current?.scrollTo({ top: scrollPos, behavior: 'instant' });
+      const scrollPos = provCellTop - activeCellTop + headerHeight - jpCellPadding;
+      // log all aprts of the computation
+      console.log('scrollToElement', {
+        activeCellTop,
+        provCellTop,
+        headerHeight,
+        jpCellPadding,
+        calc: `${provCellTop} - ${activeCellTop} + ${headerHeight} - ${jpCellPadding}`,
+        scrollPos
+      });
+      stateScrollerRef.current?.scrollTo({ top: scrollPos, behavior: 'instant' });
     }
   };
 
-  useEffect(() => {
-    scrollToElement();
-  }, [activeCellTop]);
+  useEffect(
+    () => {
+      scrollToElement();
+    } //, [activeCellTop] // commented out: dpeend on activeCellTop --> run if the value changes
+    //currently: no dependency --> run on every render
+  );
 
   const cellIDs = state.cells.map(cell => cell.id);
   const previousCellIDs = previousState?.cells.map(cell => cell.id);
@@ -208,24 +236,24 @@ export function State({ state, stateNo, previousState, stateDoI, cellExecutionCo
 
   return (
     <div
-      ref={stateWrapperRef}
       className={cx(classes.stateWrapper, {
-        // removed  'jp-Notebook' class
         [classes.wideState]: fullWidth // disable flexShrink if the state is full width
       })}
     >
-      <div className={cx(classes.state, 'state')}>
-        <header ref={stateHeaderRef}>
-          <Center>
-            <ActionIcon onClick={toggleFullwidth} title={fullWidth ? 'collapse' : 'expand'}>
-              {fullWidth ? <IconArrowsDiff /> : <IconArrowsHorizontal />}
-            </ActionIcon>
-          </Center>
-        </header>
-        <div style={{ height: '100vh' }}></div>
-        {cells}
-        <div className={cx(classes.versionSplit)}>v{stateNo}</div>
-        <div style={{ height: '100vh' }}></div>
+      <header ref={stateHeaderRef} className={cx(classes.header, classes.dashedBorder)}>
+        <Center>
+          <ActionIcon onClick={toggleFullwidth} title={fullWidth ? 'collapse' : 'expand'}>
+            {fullWidth ? <IconArrowsDiff /> : <IconArrowsHorizontal />}
+          </ActionIcon>
+        </Center>
+      </header>
+      <div ref={stateScrollerRef} className={classes.stateScroller}>
+        <div className={cx(classes.state, 'state')}>
+          <div style={{ height: '100vh' }} className={classes.dashedBorder}></div>
+          {cells}
+          <div className={cx(classes.versionSplit)}>v{stateNo}</div>
+          <div style={{ height: '100vh' }}></div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION

* loops header is now jsut one line high. notebook name is truncated if too long
* state header (to expand/minimize) is now always visible at the top

![image](https://github.com/jku-vds-lab/loops/assets/10337788/d684c81d-63e5-4bcb-be27-5f390f3740e5)
