### PR TITLE
Show code of unchanged cells on hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ With the above requirements fullfilled, you will see the following popup when op
 Alternatively, you can also reopen the project in a devcontainer via the command prompt:
 ![VS Code command prmpt](https://github.com/jku-vds-lab/loops/assets/10337788/e2f624a0-9238-4d32-856b-7e47c937a496)
 
-
 By reopening in the container, you will get an environment with Jupyter Lab and the packages from the docker image and it will also install all dependencies of the extension and the extension itself.
 
 All you need to do, is running `jlpm watch` in the VS Code terminal afterwards. The terminal can also be used to add further python packages.

--- a/src/Overview/State.tsx
+++ b/src/Overview/State.tsx
@@ -111,9 +111,8 @@ const useStyles = createStyles((theme, _params, getRef) => ({
     borderBottomRightRadius: '0.5rem'
   },
   unchanged: {
-    color: 'transparent !important',
-    ['*']: {
-      color: 'transparent !important'
+    '&.transparent *': {
+      color: 'transparent'
     }
   },
   output: {
@@ -410,7 +409,19 @@ export function State({ state, stateNo, previousState, stateDoI, cellExecutionCo
         // no change, but full width and active --> show input as it is
         input = (
           <div
-            className={cx(classes.unchanged, 'input')}
+            className={cx(classes.unchanged, 'unchanged', 'transparent', 'input')}
+            onMouseEnter={e => {
+              (e.target as HTMLDivElement)
+                .closest('.jp-Cell')
+                ?.querySelectorAll('.unchanged')
+                .forEach(elem => elem.classList.remove('transparent'));
+            }}
+            onMouseLeave={e => {
+              (e.target as HTMLDivElement)
+                .closest('.jp-Cell')
+                ?.querySelectorAll('.unchanged')
+                .forEach(elem => elem.classList.add('transparent'));
+            }}
             dangerouslySetInnerHTML={{ __html: (cell.inputHTML as HTMLElement).outerHTML }}
           />
         );
@@ -418,7 +429,7 @@ export function State({ state, stateNo, previousState, stateDoI, cellExecutionCo
         // no change, not active, or not full width --> don't show input at all
         // just indicate the code cell
         input = (
-          <div className={cx(classes.unchanged, 'input')}>
+          <div className={cx(classes.unchanged, 'unchanged', 'transparent', 'input')}>
             <div className={cx('jp-Editor', 'jp-InputArea-editor')}>
               <div style={{ height: '0.5em' }}></div>
             </div>
@@ -466,15 +477,27 @@ export function State({ state, stateNo, previousState, stateDoI, cellExecutionCo
                 // no change, but full width and active --> show output as it is
                 return (
                   <div
-                    className={cx(classes.unchanged, 'output')}
+                    className={cx(classes.unchanged, 'unchanged', 'transparent', 'output')}
                     dangerouslySetInnerHTML={{ __html: (output as HTMLElement).outerHTML }}
+                    onMouseEnter={e => {
+                      (e.target as HTMLDivElement)
+                        .closest('.jp-Cell')
+                        ?.querySelectorAll('.unchanged')
+                        .forEach(elem => elem.classList.remove('transparent'));
+                    }}
+                    onMouseLeave={e => {
+                      (e.target as HTMLDivElement)
+                        .closest('.jp-Cell')
+                        ?.querySelectorAll('.unchanged')
+                        .forEach(elem => elem.classList.add('transparent'));
+                    }}
                   />
                 );
               } else {
                 // no change, not active, or not full width --> don't show output at all
                 // just indicate the output
                 return (
-                  <div className={cx(classes.unchanged, 'output')}>
+                  <div className={cx(classes.unchanged, 'unchanged', 'transparent', 'output')}>
                     <div style={{ height: '0.5em' }}></div>
                   </div>
                 );
@@ -489,7 +512,7 @@ export function State({ state, stateNo, previousState, stateDoI, cellExecutionCo
                 // if the state is not full width, don't show the output at all
                 // just indicate the output
                 return (
-                  <div className={cx(classes.unchanged, 'output')}>
+                  <div className={cx(classes.unchanged, 'unchanged', 'transparent', 'output')}>
                     <div style={{ height: '0.5em' }}></div>
                   </div>
                 );


### PR DESCRIPTION
Closes #30 

The text in input and each output are set to transparent individually, if there were not changes.
If any input or output is hovered, the content of all of them is revealed:

![hover changes](https://github.com/jku-vds-lab/loops/assets/10337788/a4f197c4-0886-402f-ab83-b6e30c3c6827)
