### PR TITLE
Add  a note when not using firefox

### DIFF
--- a/src/Overview/OverviewHeader.tsx
+++ b/src/Overview/OverviewHeader.tsx
@@ -3,7 +3,7 @@ import { jupyterIcon, LabIcon } from '@jupyterlab/ui-components';
 import React, { useEffect, useRef, useState } from 'react';
 import { LoopsLogo } from '../assets/loops-logo';
 import { createStyles, Dialog, Modal, Text } from '@mantine/core';
-import { useIsVisible } from '../util';
+import { useIsVisible } from '../useIsVisible';
 import { useDisclosure } from '@mantine/hooks';
 
 const useStyles = createStyles((theme, _params) => ({

--- a/src/Overview/OverviewHeader.tsx
+++ b/src/Overview/OverviewHeader.tsx
@@ -1,8 +1,10 @@
 import { ILabShell } from '@jupyterlab/application';
 import { jupyterIcon, LabIcon } from '@jupyterlab/ui-components';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { LoopsLogo } from '../assets/loops-logo';
-import { createStyles } from '@mantine/core';
+import { createStyles, Dialog, Modal, Text } from '@mantine/core';
+import { useIsVisible } from '../util';
+import { useDisclosure } from '@mantine/hooks';
 
 const useStyles = createStyles((theme, _params) => ({
   loopsHeader: {
@@ -33,6 +35,23 @@ export function OverviewHeader({ labShell }: IOverviewHeaderProps): JSX.Element 
 
   const [icon, setIcon] = useState<LabIcon | undefined>(jupyterIcon);
 
+  const ref = useRef<HTMLElement>(null);
+  const isVisible = useIsVisible(ref);
+  const [opened, { open, close }] = useDisclosure(false);
+  const [modalOpened, setModalOpened] = useState(false);
+
+  useEffect(() => {
+    console.log('🚨 Loops is visible?', isVisible);
+    if (isVisible && !modalOpened && title.includes('.ipynb')) {
+      //check if we are in firefox
+      const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+      if (!isFirefox) {
+        setModalOpened(true);
+        open();
+      }
+    }
+  }, [isVisible, title]);
+
   useEffect(() => {
     const handleFocusChange = (sender: ILabShell, labShellArgs: ILabShell.IChangedArgs): void => {
       setTitle(labShellArgs.newValue?.title.label ?? 'None');
@@ -53,7 +72,7 @@ export function OverviewHeader({ labShell }: IOverviewHeaderProps): JSX.Element 
   }, [labShell]);
 
   return (
-    <header className={classes.loopsHeader}>
+    <header ref={ref} className={classes.loopsHeader}>
       <div className={classes.title}>
         <LoopsLogo height={38} />
       </div>
@@ -67,6 +86,18 @@ export function OverviewHeader({ labShell }: IOverviewHeaderProps): JSX.Element 
         )}
         {title}
       </div>
+      <Modal
+        opened={opened}
+        onClose={close}
+        title="🚨 Please Note"
+        transitionProps={{ transition: 'fade', duration: 600, timingFunction: 'linear' }}
+      >
+        <Text size="md" mb="xs" weight={500}>
+          Loops is currently in active development and is best experienced using Firefox. While fully functional on
+          other browsers, please be aware that the styling may not be as comprehensive, resulting in a suboptimal visual
+          display of the extension.
+        </Text>
+      </Modal>
     </header>
   );
 }

--- a/src/useIsVisible.ts
+++ b/src/useIsVisible.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+// src: https://dev.to/jmalvarez/check-if-an-element-is-visible-with-react-hooks-27h8
+export function useIsVisible(ref) {
+  const [isIntersecting, setIntersecting] = useState(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(([entry]) => setIntersecting(entry.isIntersecting));
+
+    observer.observe(ref.current);
+    return () => {
+      observer.disconnect();
+    };
+  }, [ref]);
+
+  return isIntersecting;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,3 @@
-import { useEffect, useState } from 'react';
-
 /**
  * Merge arrays, preserving order of elements
  * @param newArray defines the order of elements
@@ -118,18 +116,3 @@ export const getScrollParent = (node: Element): Element => {
   }
   return document.scrollingElement || document.documentElement;
 };
-
-export function useIsVisible(ref) {
-  const [isIntersecting, setIntersecting] = useState(false);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(([entry]) => setIntersecting(entry.isIntersecting));
-
-    observer.observe(ref.current);
-    return () => {
-      observer.disconnect();
-    };
-  }, [ref]);
-
-  return isIntersecting;
-}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 /**
  * Merge arrays, preserving order of elements
  * @param newArray defines the order of elements
@@ -116,3 +118,18 @@ export const getScrollParent = (node: Element): Element => {
   }
   return document.scrollingElement || document.documentElement;
 };
+
+export function useIsVisible(ref) {
+  const [isIntersecting, setIntersecting] = useState(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(([entry]) => setIntersecting(entry.isIntersecting));
+
+    observer.observe(ref.current);
+    return () => {
+      observer.disconnect();
+    };
+  }, [ref]);
+
+  return isIntersecting;
+}


### PR DESCRIPTION

When launched from browsers other than firefox, the following modal is displayed:

![image](https://github.com/jku-vds-lab/loops/assets/10337788/9257c9aa-4d8e-4bc6-9197-0b65d514d030)


The modal will be shown when:

* the browser is not firefox, AND
* the loops sidebar is visible, AND
* a notebook is opened, AND 
* if it has not be shown before.