### PR TITLE
Fix cell order for deleted cells

### DIFF
--- a/src/__tests__/mergeArray.spec.ts
+++ b/src/__tests__/mergeArray.spec.ts
@@ -1,23 +1,23 @@
 import { mergeArrays } from '../util';
 
 describe('mergeArrays', () => {
-  it('merges arrays while preserving order and removing duplicates', () => {
+  it('merges arrays while preserving order and removing duplicates (1)', () => {
     const newerArray: string[] = ['id1', 'id2', 'id3', 'id4'];
     const olderArray: string[] = ['id1', 'id5', 'id3'];
 
     const mergedArray: string[] = mergeArrays(newerArray, olderArray);
 
-    expect(mergedArray).toEqual(['id1', 'id2', 'id5', 'id3', 'id4']);
+    expect(mergedArray).toEqual(['id1', 'id5', 'id2', 'id3', 'id4']);
   });
 
-  it('merges arrays while preserving order and removing duplicates', () => {
+  it('merges arrays while preserving order and removing duplicates (2)', () => {
     const newerArray: string[] = ['id1', 'id2', 'id3', 'id4', 'id6', 'id7']; // missing id5, add id3
     const olderArray: string[] = ['id1', 'id2', 'id4', 'id5', 'id6', 'id7']; // missing id3
 
     const mergedArray: string[] = mergeArrays(newerArray, olderArray);
 
     console.log(mergedArray);
-    expect(mergedArray).toEqual(['id1', 'id2', 'id3', 'id4', 'id5', 'id6', 'id7']);
+    expect(mergedArray).toEqual(['id1', 'id2', 'id3', 'id5', 'id4', 'id6', 'id7']);
   });
 
   it('merges arrays with oldArray being shorter than newArry', () => {
@@ -56,7 +56,7 @@ describe('mergeArrays', () => {
 
     const mergedArray: string[] = mergeArrays(newerArray, olderArray);
 
-    expect(mergedArray).toEqual(['id1', 'id2', 'id5', 'id3']);
+    expect(mergedArray).toEqual(['id1', 'id5', 'id2', 'id3']);
   });
 
   it('merges arrays with newArray being empty', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -18,16 +18,16 @@ export function mergeArrays(newArray: string[], oldArray: string[] | undefined):
     const newId = newArray[i];
     const oldId = oldArray[i];
 
-    // first add id from newArray (precedence order)
-    if (newId !== undefined) {
-      // could be out of bounds already when oldArray is longer
-      mergedArray.push(newId);
-    }
-
     // if the ids are different or the newArray is already over
     // and oldID is not in newArray, add it to the mergedArray
     if (oldId !== undefined && oldId !== newId && !newArray.includes(oldId)) {
       mergedArray.push(oldId);
+    }
+
+    // first add id from newArray (precedence order)
+    if (newId !== undefined) {
+      // could be out of bounds already when oldArray is longer
+      mergedArray.push(newId);
     }
   }
 


### PR DESCRIPTION

Lines between cells crossed when when a cell was deleted:
![image](https://github.com/jku-vds-lab/loops/assets/10337788/a11feffe-d7e4-47b0-9322-0119e2d67bd2)


Adapted merging algorithm to avoid line crossings:
![image](https://github.com/jku-vds-lab/loops/assets/10337788/7a55953d-1e6a-421d-af13-58b6f7d6d56c)
